### PR TITLE
Corrections to run Microchip code with ceedling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ This project requires that the following is installed on your computer
 * Ruby (http://rubyinstaller.org/)
 * Ceedling gem (gem install ceedling)
 * Microchip XC16 compiler - Cross-platform C compiler for 16 bit PICs (http://www.microchip.com/pagehandler/en_us/promo/mplabxc/)
+
+=========================
+
+Edit: 11/01/2021
+
+* You only need to change XC16 compiler path (line 34) inside "project.yml" file to yours. 
+
+

--- a/project.yml
+++ b/project.yml
@@ -31,7 +31,7 @@
   :support:
     - test/support
   :include:
-    - "C:/Program Files (x86)/Microchip/xc16/v1.10/support/PIC24H/h/"
+    - "C:/ProgramFiles/Microchip/xc16/v1.61/support/PIC24H/h/"
 
 :defines:
   # in order to add common defines:
@@ -78,7 +78,7 @@
       - -I"$": COLLECTION_PATHS_TEST_SUPPORT_SOURCE_INCLUDE_VENDOR
       - -Wall
       #- -Werror  # We can't keep this on during test becuase of a CMock pointer issue
-      - -Os
+      # - -Os # This works only with paid XC16 compiler versions
       - -mlarge-code
       - -mlarge-arrays
   :test_linker:
@@ -108,7 +108,7 @@
       - -D$: COLLECTION_DEFINES_RELEASE_AND_VENDOR
       - -Wall
       - -Werror
-      - -Os
+      # - -Os # This works only with paid XC16 compiler versions
       - -mlarge-code
       - -mlarge-arrays
   :release_linker:

--- a/test/simulation/out.txt
+++ b/test/simulation/out.txt
@@ -1,4 +1,4 @@
-test_system.c:12:test_ShouldAbortApp_should_return_false_for_now:PASS
------------------------
-1 Tests 0 Failures 0 Ignored
-OK
+test_system.c:12:test_ShouldAbortApp_should_return_false_for_now:PASS
+-----------------------
+1 Tests 0 Failures 0 Ignored
+OK

--- a/test/simulation/sim_test_fixture.rb
+++ b/test/simulation/sim_test_fixture.rb
@@ -4,6 +4,5 @@ IO.popen("sim30 test/simulation/sim_instructions.txt")
 sleep 1
 if File.exists? OUT_FILE 
     file_contents = File.read OUT_FILE
-    file_contents.gsub!("\n", "")
     print file_contents
 end


### PR DESCRIPTION
I've tried to run this Microchip example and it does not run. For some reason, the line inside "sim_text_fixture.rb" that changes '\n' for '' causes an error and ceedling stop all tests.

I remove it and the "-Os" Xc16 compiler parameter, this only works with paid versions.

Now you can clone, change XC16 path inside "project.yml" file and run ceedling with no errors.